### PR TITLE
Update whitelist IPs; mark staging registry as decommissioned

### DIFF
--- a/docs/developer-docs/about-ondc.md
+++ b/docs/developer-docs/about-ondc.md
@@ -397,7 +397,7 @@ ONDC operates three environments:
 
 | Environment        | Registry URL                | Purpose                            |
 | ------------------ | --------------------------- | ---------------------------------- |
-| **Staging**        | `staging.registry.ondc.org` | Initial development and testing    |
+| **Staging** _(decommissioned)_ | `staging.registry.ondc.org` | Initial development and testing    |
 | **Pre-Production** | `preprod.registry.ondc.org` | Integration testing with other NPs |
 | **Production**     | `prod.registry.ondc.org`    | Live transactions with real users  |
 

--- a/docs/developer-docs/ondc-FAQs.md
+++ b/docs/developer-docs/ondc-FAQs.md
@@ -142,10 +142,8 @@ ONDC uses two distinct identifiers for subscribers. While both identify particip
 3. If you have a firewall or IP blocking on your server, whitelist the following IPs:
 
 ```
-34.131.40.9    34.131.211.247   34.131.201.63   34.131.180.63
-34.131.78.219  34.93.10.146     35.200.143.183  34.93.118.120
-35.200.183.209 34.93.102.253    35.200.232.136  34.100.170.176
-107.178.231.181/32
+34.180.45.0    34.14.149.105  35.200.173.69
+34.131.150.58  34.14.133.118  34.131.106.249
 ```
 
 ---
@@ -439,7 +437,7 @@ Lookup v2.0 is an ONDC Registry API that allows participants (BAPs, BPPs, etc.) 
 
 | Environment | Endpoint                                        |
 | ----------- | ----------------------------------------------- |
-| Staging     | `https://staging.registry.ondc.org/v2.0/lookup` |
+| Staging _(decommissioned)_ | `https://staging.registry.ondc.org/v2.0/lookup` |
 | Pre-Prod    | `https://preprod.registry.ondc.org/v2.0/lookup` |
 | Production  | `https://prod.registry.ondc.org/v2.0/lookup`    |
 

--- a/docs/developer-docs/registry-gateway.md
+++ b/docs/developer-docs/registry-gateway.md
@@ -67,7 +67,7 @@ If you need to find a counterparty's callback URL or verify they're a valid NP, 
 
 | Environment    | `/subscribe`                               | `/v2.0/lookup`                          |
 | -------------- | ------------------------------------------ | --------------------------------------- |
-| **Staging**    | `staging.registry.ondc.org/subscribe`      | `staging.registry.ondc.org/v2.0/lookup` |
+| **Staging** _(decommissioned)_ | `staging.registry.ondc.org/subscribe`      | `staging.registry.ondc.org/v2.0/lookup` |
 | **Pre-Prod**   | `preprod.registry.ondc.org/ondc/subscribe` | `preprod.registry.ondc.org/v2.0/lookup` |
 | **Production** | `prod.registry.ondc.org/subscribe`         | `prod.registry.ondc.org/v2.0/lookup`    |
 


### PR DESCRIPTION
## What
- Replaces the registry/gateway **IP whitelist** with the new **pre-prod** and **production** IPs in `docs/developer-docs/ondc-FAQs.md`.
- Tags the **staging** registry rows as **decommissioned** in `about-ondc.md`, `ondc-FAQs.md`, and `registry-gateway.md`.

## Why
Registry/gateway infrastructure migration — new whitelist IPs; staging environment retired.